### PR TITLE
fix : zero wide Unicode tag

### DIFF
--- a/src/tools/security.py
+++ b/src/tools/security.py
@@ -65,14 +65,30 @@ ZERO_WIDTH_CHARS = [
     '\uffa0',  # Halfwidth hangul filler
 ]
 
+# Additional Unicode smuggling vectors (comprehensive coverage)
+_UNICODE_SMUGGLING_PATTERNS = [
+    r'[\U000E0000-\U000E007F]',  # Unicode Tags - Language tag smuggling
+    r'[\uFE00-\uFE0F]',           # Variation Selectors (Standard) - Invisible modifiers
+    r'[\U000E0100-\U000E01EF]',   # Variation Selectors (Extended) - Extended invisible modifiers
+    r'[\u202A-\u202E]',           # Directional Formatting - Bidi overrides
+]
+
 # Pre-compile regex for stripping zero-width chars (fast)
 _zero_width_pattern = re.compile('[' + ''.join(ZERO_WIDTH_CHARS) + ']')
+
+# Pre-compile comprehensive Unicode smuggling patterns
+_smuggling_pattern = re.compile('|'.join(_UNICODE_SMUGGLING_PATTERNS))
 
 
 def strip_zero_width(content: str) -> str:
     """Remove zero-width and invisible Unicode characters.
 
     Prevents obfuscation attacks like: I​G​N​O​R​E (with zero-width spaces)
+
+    Now also covers:
+    - Unicode Tags (U+E0000-E007F) - Language tag smuggling
+    - Variation Selectors (U+FE00-FE0F, U+E0100-E01EF) - Invisible modifiers
+    - Directional Formatting (U+202A-E) - Bidi overrides
 
     Args:
         content: Raw content
@@ -82,7 +98,11 @@ def strip_zero_width(content: str) -> str:
     """
     if not content:
         return content
-    return _zero_width_pattern.sub('', content)
+    # Remove traditional zero-width chars
+    result = _zero_width_pattern.sub('', content)
+    # Remove additional Unicode smuggling vectors
+    result = _smuggling_pattern.sub('', result)
+    return result
 
 
 def has_injection_markers(content: str) -> bool:
@@ -142,6 +162,13 @@ def detect_injection_patterns(content: str) -> list[str]:
 def sanitize_content(content: str, replacement: str = "[FILTERED]") -> str:
     """Remove known injection patterns and zero-width characters from content.
 
+    Comprehensive filter covering:
+    - Zero-width characters (U+200B-D, U+FEFF, etc.)
+    - Unicode Tags (U+E0000-E007F) - Language tag smuggling
+    - Variation Selectors (U+FE00-FE0F, U+E0100-E01EF) - Invisible modifiers
+    - Directional Formatting (U+202A-E) - Bidi overrides
+    - Injection patterns (SYSTEM:, IGNORE PREVIOUS, etc.)
+
     Lightweight filter - O(n) where n is content length.
     Does NOT guarantee safety, just removes obvious attacks.
 
@@ -155,7 +182,7 @@ def sanitize_content(content: str, replacement: str = "[FILTERED]") -> str:
     if not content:
         return content
 
-    # First strip zero-width characters
+    # First strip zero-width characters (now includes Unicode smuggling vectors)
     result = strip_zero_width(content)
 
     # Then remove injection patterns
@@ -202,20 +229,23 @@ def wrap_untrusted(
 def wrap_and_check(
     content: str,
     label: str = "PAGE_DATA",
-    log_injections: bool = True
+    log_injections: bool = True,
+    sanitize: bool = True
 ) -> tuple[str, bool]:
     """Wrap content and check for injection patterns.
 
-    Convenience function combining wrapping with detection.
+    Now sanitizes content before wrapping to prevent Unicode smuggling attacks.
 
     Args:
         content: Untrusted content
         label: Content type label
         log_injections: Whether to log detected patterns
+        sanitize: Whether to sanitize content (remove injection patterns) before wrapping
 
     Returns:
         (wrapped_content, has_suspicious_patterns)
     """
+    # First, check for injection patterns in original content
     suspicious = has_injection_markers(content)
 
     if suspicious and log_injections:
@@ -225,7 +255,10 @@ def wrap_and_check(
             file=sys.stderr
         )
 
-    wrapped = wrap_untrusted(content, label)
+    # Sanitize content if enabled (default: True)
+    content_to_wrap = sanitize_content(content) if sanitize else content
+
+    wrapped = wrap_untrusted(content_to_wrap, label)
     return wrapped, suspicious
 
 
@@ -242,4 +275,5 @@ __all__ = [
     "strip_zero_width",
     "INJECTION_PATTERNS",
     "ZERO_WIDTH_CHARS",
+    "_UNICODE_SMUGGLING_PATTERNS",
 ]


### PR DESCRIPTION
This pull request enhances the Unicode security filtering in `src/tools/security.py` by expanding detection and removal of Unicode-based smuggling vectors and improving the sanitization process for untrusted content. The changes aim to prevent obfuscation and injection attacks that leverage invisible or special Unicode characters.

**Unicode security improvements:**

* Added `_UNICODE_SMUGGLING_PATTERNS` to detect and remove Unicode Tags, Variation Selectors, and Directional Formatting characters, which are common vectors for Unicode smuggling and obfuscation attacks.
* Updated the `strip_zero_width` function to remove both traditional zero-width characters and the new Unicode smuggling patterns, providing more comprehensive filtering.

**Content sanitization enhancements:**

* Improved documentation for `sanitize_content` to reflect its expanded coverage of Unicode smuggling vectors and injection patterns.
* Updated `sanitize_content` to clarify that it now removes both zero-width and Unicode smuggling vectors before filtering injection patterns.

**API and usability improvements:**

* Modified `wrap_and_check` to sanitize content by default before wrapping, reducing the risk of Unicode smuggling attacks in wrapped untrusted data. Added a `sanitize` parameter to allow opt-out if needed. [[1]](diffhunk://#diff-4df788eec39ed94be41a5ac5f792d0e337033c4c2117a3bd6671b631b1eb1d52L205-R248) [[2]](diffhunk://#diff-4df788eec39ed94be41a5ac5f792d0e337033c4c2117a3bd6671b631b1eb1d52L228-R261)
* Exported `_UNICODE_SMUGGLING_PATTERNS` in the module's `__all__` list for potential external use or testing.